### PR TITLE
Add GAB 2018 event

### DIFF
--- a/_posts/events/2018-04-21---global-azure-bootcamp.md
+++ b/_posts/events/2018-04-21---global-azure-bootcamp.md
@@ -1,0 +1,35 @@
+---
+layout: single
+title: "2018-04-21 - Global Azure Bootcamp 2018"
+date: 2017-11-25 13:37:00 +0000
+comments: true
+published: true
+categories: ["events"]
+tags: ["Events"]
+alias: ["/events/2018-04-21---global-azure-bootcamp"]
+author: Tom Kerkhove
+redirect_from:
+ - /events/2018-04-21---global-azure-bootcamp.html
+ - /events/2018/04/2112/global-azure-bootcamp.html
+---
+
+AZUG is glad to support the 6th edition of the Global Azure Bootcamp by hosting an event on Saturday 21nd of April in Belgium.
+
+We will host a full day of Azure sessions, labs or just provide a workspace for people who have been thinking of a side project but are looking for a partner in crime.
+
+## Agenda
+We are looking for your interesting sessions to build our agenda.
+
+Feel free to submit them on our [call for paper](https://sessionize.com/global-azure-bootcamp-2018-azug/)!
+
+## Practical details
+**Event date:** April 21, 2018
+
+**Event location:**<br />
+itnetX<br />
+Ruisstraat 226<br />
+9140 Temse<br />
+Belgium
+
+## Register via EventBrite
+<div style="width:100%; text-align:left;"><iframe src="//eventbrite.com/tickets-external?eid=38977193836&ref=etckt" frameborder="0" height="275" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:12px; padding:10px 0 5px; margin:2px; width:100%; text-align:left;" ><a class="powered-by-eb" style="color: #ADB0B6; text-decoration: none;" target="_blank" href="http://www.eventbrite.com/">Powered by Eventbrite</a></div></div>

--- a/index.md
+++ b/index.md
@@ -13,8 +13,10 @@ excerpt: "The Belgium Azure User Group focuses on knowledge sharing and networki
 ---
 
 ## Upcoming events
-
 **2017-12-12 - Serverless CQRS & Approaches to application request throttling** - Serverless CQRS in Azure by Toon Vanhoutte, and Approaches to application request throttling by Maarten Balliauw. [Register here!](/events/2017-12-12---serverless-cqrs-approaches-to-application-request-throttling){: .btn .btn--success}
+{: .notice--info}
+
+**2018-04-21 - Global Azure Bootcamp 2018** - AZUG is glad to support the 6th edition of the Global Azure Bootcamp by hosting an event on Saturday 21nd of April in Belgium. [Register here!](/events/events/2018-04-21---global-azure-bootcamp){: .btn .btn--success}
 {: .notice--info}
 
 <hr />


### PR DESCRIPTION
Add GAB 2018 event.

Think the Eventbrite section is correct, but not sure.
Will check with @KrisvanderMast for the logo and add it afterwards.