### PR TITLE
Make travel policy public

### DIFF
--- a/_pages/speakers/travel-policy.md
+++ b/_pages/speakers/travel-policy.md
@@ -2,7 +2,7 @@
 layout: single
 title: Travel Policy
 tagline: Azure User Group Belgium
-permalink: /travel-policy
+permalink: /speakers/travel-policy
 ---
 
 Please note that this travel policy is applicable exclusively for speakers at events organized by AZUG.

--- a/_pages/travel-policy.md
+++ b/_pages/travel-policy.md
@@ -1,0 +1,53 @@
+---
+layout: single
+title: Travel Policy
+tagline: Azure User Group Belgium
+permalink: /travel-policy
+---
+
+Please note that this travel policy is applicable exclusively for speakers at events organized by AZUG.
+
+As an invited speaker, AZUG may reimburse reasonable costs associated with your travel to/from the event, as well as accommodation for the previous and/or following night when required. In general, you should note that all other expenses will _not_ be reimbursed. When in doubt, please reach out to your contacts at AZUG before making the expense.
+
+## Event entry
+
+Event admittance is free for you as a speaker. You're speaking, so we welcome you to join and enjoy the rest of the event as well.
+
+## Transportation
+
+### Bus, train, plane
+
+AZUG will cover transport to/from the event in coach or economy, whether it is a bus, train or plane, unless otherwise agreed. For air travel, AZUG will work with you to book your flights, unless agreed otherwise.
+
+Airport transfers should always be made using the most economical transportation option, for example a ride share app, bus or train. When those options are not available, AZUG may cover taxi costs. For your port of origin, AZUG may cover fuel cost for getting there using the rules specified under "Car".
+
+Rental cars will not be reimbursed.
+
+### Car
+
+When using personal automobile transportation, AZUG will reimburse fuel cost when that cost does not exceed reasonable cost for the traveled distance.
+
+Parking costs will be reimbursed when it is required to use paid car parks near the event location.
+
+## Accommodation
+
+AZUG may reimburse reasonable costs associated with accommodation for the night previous and/or following the event, when required. Typically, AZUG will work with you to book hotel or other accommodation, unless agreed otherwise.
+
+## Meals
+
+AZUG does not reimburse meals, unless otherwise agreed. For larger events, AZUG may provide breakfast/lunch/dinner.
+
+## Other expenses
+
+No other expenses will be covered by AZUG, including but not limited to hotel-related expenses (pay TV, valet, bar, mini bar, telephone, internet connection, etc.); flight insurance; presentation preparation of slides, overheads, handouts, etc; audiovisual equipment; entertainment of other speakers, attendees, spouse, etc.; or the cost of purely personal items, such as clothing, jewelry, entertainment, souvenirs, personal telephone calls, gifts, and laundry service.
+
+When in doubt, please reach out to your contacts at AZUG before making the expense.
+
+## Expense reports
+
+Expense reports should be delivered to AZUG no later than 1 month (30 days) following the event. Expense reports received outside that period will not be taken into consideration.
+
+Please send AZUG the original receipts, as well as your name, IBAN bank account number, SWIFT/BIC code and the total amount in EUR.
+An invoice is preferred when possible, but not required.
+
+Contact e-mail address: [info@azug.be](mailto:info@azug.be?subject=Travel-Reimbursement)


### PR DESCRIPTION
To promote inclusiveness, making this public instead of private. Given we cover reasonable expenses anyway, why not say it in the open...

Once merged, drop https://github.com/AzugBe/Operations/wiki/Travel-Policy