### PR TITLE
add first speaker of april

### DIFF
--- a/_posts/events/2025-04-03---azug2025-02.md
+++ b/_posts/events/2025-04-03---azug2025-02.md
@@ -13,9 +13,12 @@ This will be our second session of the year! See you there?
 
 ## Agenda
 
-### Session TBA
+### Honey, I shrunk the DEV team...
 
-**Speaker:  TBA**
+<img src="/assets/media/speakers/wouter-vercruysse.png" alt="Wouter Vercruysse" align="right" height="100" width="100" style="margin-right: 20px;">
+What happens when a team based effort suddenly changes into a solo endeavor? How does a one-man-does-all compare to a divided effort? This session entails my experience in a project where exactly this happened, and reports on my findings.
+
+**Speakers: Wouter Vercruysse**
 
 ### Session TBA
 


### PR DESCRIPTION
This pull request includes an update to the event details in the `_posts/events/2025-04-03---azug2025-02.md` file. The most important changes include updating the session title, adding speaker details, and providing a description of the session.

Event details update:

* Changed the session title to "Honey, I shrunk the DEV team..."
* Added speaker details: Wouter Vercruysse, including an image and description of the session