### PR TITLE
add build watch party at delaware

### DIFF
--- a/_posts/events/2025-05-19---azug2025-03.md
+++ b/_posts/events/2025-05-19---azug2025-03.md
@@ -1,0 +1,36 @@
+---
+layout: single
+title: "2025-05-19 - Azug Session May"
+date: 2025-05-19 18:00:00 +0000
+comments: true
+published: true
+categories: ["events"]
+tags: ["Events"]
+author: ["Glenn Colpaert"]
+---
+
+For our third session this year we are teaming up with delaware.
+We invite you to experience Microsoft Build togheter with some streetfood, drinks & snacks.
+
+## Agenda 
+
+Check <a href="https://www.delaware.pro/en-be/careers/events/microsoft-build-watch-party-2025" target="_blank">Microsoft Build Watch Party 2025</a> for more information!
+
+The yearly Microsoft Build is coming up! Can’t make it to Seattle, but plan on watching from home? Togheter with delaware we’re hosting the third edition of our watch party, and you're invited. We’re opening up our offices to again join and experience Microsoft Build together. Because when it comes to geeking out over a Microsoft Keynote, “the more, the merrier” definitely counts.   
+
+Happy to note that this year we're partnering up with AZUG as our co-host, to give you not just livestreamed keynotes, but also short & sweet in-person tech sessions by delaware, AZUG & Microsoft speakers. A cosy & casual evening full of knowledge sharing among peers - registrations below!
+
+## Practical details
+
+**Event date:** May 19th, 2025 - timetable TBA.
+
+**Event location:**<br />
+
+<img width="120" height="60" align="right" alt="Delaware" src="/assets/media/sponsors/logo-delaware.png">delaware Ghent Office<br/>
+Amélia Earheartlaan 10 (Pégoud building) <br/>
+9051 Ghent<br/>
+Belgium
+
+## Register via Partner Event Page
+
+**Check <a href="https://www.delaware.pro/en-be/careers/events/microsoft-build-watch-party-2025" target="_blank">Microsoft Build Watch Party 2025</a> for more information!**

--- a/index.md
+++ b/index.md
@@ -14,11 +14,12 @@ excerpt: "The Belgium Azure User Group focuses on knowledge sharing and networki
 
 ## Upcoming events
 
-**2025-02-27 - Session at ACA Group**<br>
-Our first session this year will be at the ACA Group offices in Antwerp and the agenda is live with 2 sessions: one on DevSecOps and one on Azure AI Foundry. See you there! [Register here!](https://www.azug.be/events/2025/02/27/azug2025-01){: .btn .btn--success}
-
 **2025-04-03 - Session at Zure**<br>
 Our second session of the year will be at the Zure offices in Ghent. The agenda is live with 2 sessions: one full-stack development and one about the launch of Azure Belgium Central. See you there! [Register here!](https://www.azug.be/events/2025/04/03/azug2025-02){: .btn .btn--success}
+
+**2025-05-19 - Build Watch Party at delaware**<br>
+For our third session this year we are teaming up with delaware.
+We invite you to experience Microsoft Build togheter with some streetfood, drinks & snacks. See you there! [Register here!](https://www.azug.be/events/2025/05/19/azug2025-03){: .btn .btn--success}
 
 <hr />
 


### PR DESCRIPTION
This pull request includes updates to the event information on the website. The changes add details about the upcoming event in May 2025 and remove outdated event information.

Event information updates:

* [`_posts/events/2025-05-19---azug2025-03.md`](diffhunk://#diff-cc4dcd7f53a3dbae15a9a5695bc491baadba5eee319c1d63a1afb4bc22761c7dR1-R36): Added a new post with details about the Azug Session in May 2025, including the agenda, practical details, and registration link.
* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L17-R23): Updated the "Upcoming events" section to include the new event on May 19, 2025, and removed the outdated event from February 2025.