### PR TITLE
add event of june at U2U

### DIFF
--- a/_posts/events/2025-04-03---azug2025-02.md
+++ b/_posts/events/2025-04-03---azug2025-02.md
@@ -41,8 +41,6 @@ Wouter is already 3 years at Microsoft, focusing on Azure infrastructure in the 
 **Event date:** April 3rd, 2025 - you are welcome from 17:30, food served at 18:00, session starts 18:30.
 
 **Event location:**<br />
-
-**Event location:**<br />
 <img width="120" height="60" align="right" alt="Zure" src="/assets/media/sponsors/logo-zure.png">Zure<br/>
 Xavier De Cocklaan 70<br/>
 9831 Sint-Martens-Latem<br/>

--- a/_posts/events/2025-06-19---azug2025-04.md
+++ b/_posts/events/2025-06-19---azug2025-04.md
@@ -1,0 +1,46 @@
+---
+layout: single
+title: "2025-06-19 - Azug Session Jue"
+date: 2025-06-19 18:00:00 +0000
+comments: true
+published: true
+categories: ["events"]
+tags: ["Events"]
+author: ["Glenn Colpaert"]
+---
+
+For our fourth session this year we are invited at the U2U offices in Zellik! See you there!
+
+## Agenda
+
+### Session 1 TBA
+
+**Speakers: TBA**
+
+### Session 2 TBA
+
+**Speaker:  TBA**
+
+## Practical details
+
+**Event date:** June 19th, 2025 - you are welcome from 17:30, food served at 18:00, session starts 18:30.
+
+**Event location:**<br />
+
+<img width="120" height="60" align="right" alt="Delaware" src="/assets/media/sponsors/logo-u2u.png">U2U Training Centrum<br/>
+Zone 1 Research Park 110/Z <br/>
+1731 Asse<br/>
+Belgium
+
+## Register via Pretix
+
+<link rel="stylesheet" type="text/css" href="https://pretix.eu/azug/20250619/widget/v1.css">
+<script type="text/javascript" src="https://pretix.eu/widget/v1.en.js" async></script>
+<pretix-widget event="https://pretix.eu/azug/20250619/" single-item-select="button"></pretix-widget>
+<noscript>
+   <div class="pretix-widget">
+        <div class="pretix-widget-info-message">
+            JavaScript is disabled in your browser. To access our ticket shop without JavaScript, please <a target="_blank" rel="noopener" href="https://pretix.eu/azug/20250619/">click here</a>.
+        </div>
+    </div>
+</noscript>

--- a/index.md
+++ b/index.md
@@ -18,6 +18,9 @@ excerpt: "The Belgium Azure User Group focuses on knowledge sharing and networki
 For our third session this year we are teaming up with delaware.
 We invite you to experience Microsoft Build togheter with some streetfood, drinks & snacks. See you there! [Register here!](https://www.azug.be/events/2025/05/19/azug2025-03){: .btn .btn--success}
 
+**2025-06-19 - Azug Session at U2U**<br>
+For our fourth session this year we are invited at the U2U offices in Zellik! See you there! [Register here!](https://www.azug.be/events/2025/06/19/azug2025-04){: .btn .btn--success}
+
 <hr />
 
 ## About AZUG


### PR DESCRIPTION
This pull request introduces updates to event details and announcements for the Belgium Azure User Group (AZUG) website. The changes include adding a new event page, updating the homepage with a new event announcement, and minor formatting adjustments.

### Event Updates:
* Added a new event page for "2025-06-19 - Azug Session at U2U," including event details, location, agenda placeholders, and a registration widget. (`_posts/events/2025-06-19---azug2025-04.md`)
* Updated the homepage to include an announcement for the new event at U2U with a registration link. (`index.md`)

### Formatting Adjustments:
* Removed duplicate "Event location" header in an existing event post for improved readability. (`_posts/events/2025-04-03---azug2025-02.md`)