### PR TITLE
update june to september

### DIFF
--- a/_posts/events/2025-09-25---azug2025-04.md
+++ b/_posts/events/2025-09-25---azug2025-04.md
@@ -1,7 +1,7 @@
 ---
 layout: single
-title: "2025-06-19 - Azug Session June"
-date: 2025-06-19 18:00:00 +0000
+title: "2025-09-25 - Azug Session June"
+date: 2025-09-25 18:00:00 +0000
 comments: true
 published: true
 categories: ["events"]
@@ -9,6 +9,7 @@ tags: ["Events"]
 author: ["Glenn Colpaert"]
 ---
 
+Event moved from June to September!
 For our fourth session this year we are invited at the U2U offices in Zellik! See you there!
 
 ## Agenda
@@ -29,11 +30,11 @@ Struggling to manage resources across on-prem, edge, and multicloud? Discover ho
 
 ## Practical details
 
-**Event date:** June 19th, 2025 - you are welcome from 17:30, food served at 18:00, session starts 18:30.
+**Event date:** September 25th, 2025 - you are welcome from 17:30, food served at 18:00, session starts 18:30.
 
 **Event location:**<br />
 
-<img width="120" height="60" align="right" alt="Delaware" src="/assets/media/sponsors/logo-u2u.png">U2U Training Centrum<br/>
+<img width="120" height="60" align="right" alt="U2U" src="/assets/media/sponsors/logo-u2u.png">U2U Training Centrum<br/>
 Zone 1 Research Park 110/Z <br/>
 1731 Asse<br/>
 Belgium

--- a/index.md
+++ b/index.md
@@ -14,12 +14,8 @@ excerpt: "The Belgium Azure User Group focuses on knowledge sharing and networki
 
 ## Upcoming events
 
-**2025-05-19 - Build Watch Party at delaware**<br>
-For our third session this year we are teaming up with delaware.
-We invite you to experience Microsoft Build togheter with some streetfood, drinks & snacks. See you there! [Register here!](https://www.azug.be/events/2025/05/19/azug2025-03){: .btn .btn--success}
-
-**2025-06-19 - Azug Session at U2U**<br>
-For our fourth session this year we are invited at the U2U offices in Zellik! See you there! [Register here!](https://www.azug.be/events/2025/06/19/azug2025-04){: .btn .btn--success}
+**2025-09-25 - Azug Session at U2U (Moved from June to September)**<br>
+For our fourth session this year we are invited at the U2U offices in Zellik! See you there! [Register here!](https://www.azug.be/events/2025/09/25/azug2025-04){: .btn .btn--success}
 
 <hr />
 


### PR DESCRIPTION
This pull request updates the event details for the Belgium Azure User Group's fourth session in 2025, reflecting a change in the event date from June to September. It also includes minor corrections to the event description and metadata.

### Event Updates:
* `_posts/events/2025-09-25---azug2025-04.md` (renamed from `_posts/events/2025-06-19---azug2025-04.md`): Updated the event date and title from June 19, 2025, to September 25, 2025, and added a note about the date change.
* [`_posts/events/2025-09-25---azug2025-04.md`](diffhunk://#diff-263f94d1efdb664dffa69ef8071a267dc602c9cfe85247f9b5e77b7f4ec1337fL32-R37): Adjusted the event date in the practical details section and corrected the sponsor's name in the location description.

### Homepage Updates:
* [`index.md`](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L17-R18): Updated the upcoming events section to reflect the new date for the fourth session and included a note about the rescheduling. Removed outdated event details for May and June.[Copilot is generating a summary...]