### PR TITLE
Welcome Axxes

### DIFF
--- a/_includes/partners.html
+++ b/_includes/partners.html
@@ -17,7 +17,7 @@
 
 			<p>Every day, our team of 400 experienced IT professionals make all the difference for our clients. We bring the right expertise to your project.</p>
 		</td>
-	</tr>
+	</tr>	
 	<!--
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-platinum" /></a></td>

--- a/_includes/partners.html
+++ b/_includes/partners.html
@@ -10,7 +10,7 @@
 			<p>With over 20 years of experience in business architecture, software engineering and change management we are a trusted partner in reshaping business critical solutions and services for over 150 customers. And counting.</p>
 		</td>
 	</tr>
-<!--	<tr>
+	<tr>
 		<td class="sponsor-platinum"><a href="https://www.axxes.com/"><img src="/assets/media/sponsors/logo-axxes.jpg" class="sponsor-platinum" /></a></td>
 		<td>
 			<p><a href="https://www.axxes.com/">Axxes</a> is a full-service IT consultancy. Our specialist IT consultants focus on delivering flexible and qualitative services in software development, quality assurance, infrastructure, devops, cloud solutions, architecture, project management services and more.</p>
@@ -18,6 +18,7 @@
 			<p>Every day, our team of 400 experienced IT professionals make all the difference for our clients. We bring the right expertise to your project.</p>
 		</td>
 	</tr>
+	<!--
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -143,8 +144,8 @@
 <!-- note: 2 columns -->
 
 <a href="https://www.ae.be/"><img src="/assets/media/sponsors/logo-ae.jpg" class="sponsor-platinum" vspace="20" /></a>&nbsp;
-<!-- <a href="https://www.axxes.com/"><img src="/assets/media/sponsors/logo-axxes.jpg" class="sponsor-platinum" vspace="20" /></a><br/>
-
+<a href="https://www.axxes.com/"><img src="/assets/media/sponsors/logo-axxes.jpg" class="sponsor-platinum" vspace="20" /></a><br/>
+<!--
 <a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-platinum" vspace="20" /></a>&nbsp;
 <a href="https://www.codit.eu/"><img src="/assets/media/sponsors/logo-codit.png" class="sponsor-platinum" vspace="20" /></a><br/>
 -->


### PR DESCRIPTION
This pull request makes adjustments to the visibility of certain platinum partners in the `_includes/partners.html` file. Specifically, it restores the visibility of the Axxes partner while commenting out the Arxus partner.

Changes to platinum partners:

* [`_includes/partners.html`](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L13-R21): Restored the Axxes partner entry by uncommenting its HTML block, making it visible in the list of platinum partners. [[1]](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L13-R21) [[2]](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L146-R148)
* [`_includes/partners.html`](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L13-R21): Commented out the Arxus partner entry, effectively hiding it from the list of platinum partners. [[1]](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L13-R21) [[2]](diffhunk://#diff-6b6ed4e0bc37767c9a6681fb7a7eb7d863cb76d9b23e01aa1a30e62a03271da4L146-R148)