### PR TITLE
fix Robs name

### DIFF
--- a/_posts/events/2026-06-03---azug2026-03.md
+++ b/_posts/events/2026-06-03---azug2026-03.md
@@ -19,7 +19,7 @@ For our third session this year we are teaming up with delaware.
 <br />
 <br />
 
-**Speaker:  Rob Hofman Vandenheede -  Microsoft integration at delaware**
+**Speaker:  Rob Hofman -  Microsoft integration at delaware**
 
 ### Second Session TBA
 


### PR DESCRIPTION
This pull request makes a minor correction to the event post by updating the speaker's name.

* Corrected the speaker's name from "Rob Hofman Vandenheede" to "Rob Hofman" in the `_posts/events/2026-06-03---azug2026-03.md` file.