### PR TITLE
add Tom for june event and update

### DIFF
--- a/_posts/events/2026-06-03---azug2026-03.md
+++ b/_posts/events/2026-06-03---azug2026-03.md
@@ -9,7 +9,8 @@ tags: ["Events"]
 author: ["Glenn Colpaert"]
 ---
 
-For our third session this year we are teaming up with delaware.
+This will be our third session of the year! See you there?
+We are invited at the Delaware offices in Ghent.
 
 ## Agenda 
 
@@ -21,9 +22,13 @@ For our third session this year we are teaming up with delaware.
 
 **Speaker:  Rob Hofman -  Microsoft integration at delaware**
 
-### Second Session TBA
+### What can the Azure SRE Agent really do?
+<img src="/assets/media/speakers/tom-claes.jpg" alt="Tom Claes" align="right" height="100" width="100" style="margin-right: 20px;">
+Recently announced as generally available, the Azure SRE Agent helps bridge the gap between detecting issues and acting on them.
 
-**Speaker:  TBA**
+In this session, you’ll learn what the SRE Agent does, where it fits in the Azure ecosystem, and why it’s becoming a key capability for teams focused on reliability and operational excellence. We’ll ground this with a real-world customer use case where the SRE Agent is already delivering value in production, explaining pricing, and conclude with a live demo to show the SRE Agent in action.
+
+**Speaker:  Tom Claes - Cloud Solution Architect @ Microsoft**
 
 ## Practical details
 

--- a/index.md
+++ b/index.md
@@ -14,11 +14,8 @@ excerpt: "The Belgium Azure User Group focuses on knowledge sharing and networki
 
 ## Upcoming events
 
-**2025-04-02 - Azug Session at Zure**<br>
-For our second session this year we are invited at the Zure offices in Sint-Martens-Latem! See you there! [Register here!](https://www.azug.be/events/2026/04/02/azug2026-02){: .btn .btn--success}
-
 **2026-06-03 - Azug Session at delaware**<br>
-For our first session this year we are invited at the delaware offices in Ghent! See you there! [Register here!](https://www.azug.be/events/2026/06/03/azug2026-03){: .btn .btn--success}
+For our third session this year we are invited at the delaware offices in Ghent! See you there! [Register here!](https://www.azug.be/events/2026/06/03/azug2026-03){: .btn .btn--success}
 
 
 <hr />


### PR DESCRIPTION
This pull request updates the event information for the upcoming Azug session in June 2026. The main changes clarify the session's sequence, update venue details, and provide a finalized agenda with speaker information.

Event details and agenda updates:

* Updated the event description in both `index.md` and the event post to clarify that this is the third session of the year, and confirmed the venue as the Delaware offices in Ghent. [[1]](diffhunk://#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5L17-R18) [[2]](diffhunk://#diff-3967691037af21e139f151ebf98a47992822488c6d8fe51ed7fbab648ece9a8cL12-R13)
* Replaced the placeholder for the second session's agenda with a detailed session on the Azure SRE Agent, including a description, real-world use case, demo, and finalized the speaker as Tom Claes from Microsoft.