### PR TITLE
update 2026 partners

### DIFF
--- a/_includes/partners.html
+++ b/_includes/partners.html
@@ -2,6 +2,7 @@
 <h2>Platinum partners</h2>
 <!-- partners page: with text -->
 <table>
+	<!--
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.ae.be/"><img src="/assets/media/sponsors/logo-ae.jpg" class="sponsor-platinum" /></a></td>
 		<td>
@@ -18,7 +19,7 @@
 			<p>Every day, our team of 400 experienced IT professionals make all the difference for our clients. We bring the right expertise to your project.</p>
 		</td>
 	</tr>	
-	<!--
+	
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -39,7 +40,7 @@
 			<p><a href="https://www.codit.eu/">Codit</a> is an innovative IT company which provides next-level consultancy, technology, and managed services to leading brands worldwide. We successfully help companies reduce operational costs, improve efficiency and enhance communication by integrating people, applications, and things, using a wide range of Microsoft technologies.</p>
 		</td>
 	</tr>
-
+<!--
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.cegeka.com/"><img src="/assets/media/sponsors/logo-cegeka.png" class="sponsor-platinum" /></a></td>
 		<td> <br /><br /><br /><br /><br />
@@ -56,7 +57,7 @@
 			<p>we commit. we deliver.</p>
 		</td>
 	</tr>
-	<!--
+	
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.devoteam.be/"><img src="/assets/media/sponsors/logo-devoteam.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -84,7 +85,7 @@
 
 			<p>At <a href="https://www.ordina.be">Ordina</a>, we help our customers stay ahead of change so that they can meet the challenges the future will bring head-on.</p>
 		</td>
-	</tr>-->
+	</tr>
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.inetum.com/"><img src="/assets/media/sponsors/logo-inetum.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -97,7 +98,6 @@
 			<p><a href="https://www.microsoft.be">Microsoft</a> enables digital transformation for the era of an intelligent cloud and an intelligent edge. Its mission is to empower every person and every organization on the planet to achieve more.</p>
 		</td>
 	</tr>
-	<!--
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.proximus.be"><img src="/assets/media/sponsors/logo-proximus.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -117,14 +117,14 @@
 
 			<p>At <a href="https://www.soprasteria.be">Sopra Steria</a>, we help our customers stay ahead of change so that they can meet the challenges the future will bring head-on.</p>
 		</td>
-	</tr> -->
+	</tr>
 	<tr>
 		<td><a href="https://spikes.be/"><img src="/assets/media/sponsors/logo-spikes-2025.png" class="sponsor-platinum" /></a></td>
 		<td>
 			<p><a href="https://spikes.be/">Spikes</a> increases the innovation potential of any organization with a holistic approach that advances people, teams and organizations at every level.
 			By making them more engaged and providing innovative solutions, we create lasting impact, increased productivity and better collaboration. In short, we accelerate your competitiveness with technology.</p>
 		</td>
-	</tr>
+	</tr>-->
 	<tr>
 		<td class="sponsor-platinum"><a href="https://www.zure.com/"><img src="/assets/media/sponsors/logo-zure.png" class="sponsor-platinum" /></a></td>
 		<td>
@@ -158,15 +158,8 @@
 <h2>Platinum partners</h2>
 <!-- note: 2 columns -->
 
-<a href="https://www.ae.be/"><img src="/assets/media/sponsors/logo-ae.jpg" class="sponsor-platinum" vspace="20" /></a>&nbsp;
-<a href="https://www.axxes.com/"><img src="/assets/media/sponsors/logo-axxes.jpg" class="sponsor-platinum" vspace="20" /></a><br/>
-<a href="https://www.cegeka.com/"><img src="/assets/media/sponsors/logo-cegeka.png" class="sponsor-platinum" vspace="20" /></a>&nbsp;
-<a href="https://www.codit.eu/"><img src="/assets/media/sponsors/logo-codit.png" class="sponsor-platinum" vspace="20" /></a><br />
-<a href="https://www.delaware.pro/"><img src="/assets/media/sponsors/logo-delaware.png" class="sponsor-platinum" vspace="20" /></a>
-<a href="https://www.inetum.com/"><img src="/assets/media/sponsors/logo-inetum.png" class="sponsor-platinum" vspace="20" /></a><br />
-<a href="https://www.microsoft.be/"><img src="/assets/media/sponsors/logo-microsoft.jpg" class="sponsor-platinum" vspace="20" /></a>&nbsp;
-<a href="https://spikes.be/"><img src="/assets/media/sponsors/logo-spikes-2025.png" class="sponsor-platinum" vspace="20" /></a><br />
-<a href="https://www.zure.com/"><img src="/assets/media/sponsors/logo-zure.png" class="sponsor-platinum" vspace="20" /></a>
+<a href="https://www.codit.eu/"><img src="/assets/media/sponsors/logo-codit.png" class="sponsor-platinum" vspace="20" /></a>&nbsp;
+<a href="https://www.zure.com/"><img src="/assets/media/sponsors/logo-zure.png" class="sponsor-platinum" vspace="20" /></a><br/>
 <!--
 
 
@@ -198,11 +191,11 @@
 		
 <h2>Silver partners</h2>
 <!-- note: 4 columns -->
- <a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-silver" vspace="20" /></a>
+<!-- <a href="https://www.arxus.eu/"><img src="/assets/media/sponsors/logo-arxus.png" class="sponsor-silver" vspace="20" /></a>
 <a href="https://integration.team/"><img src="/assets/media/sponsors/logo-integrationteam.png" class="sponsor-silver" vspace="20" /></a>
 <a href="https://www.u2u.be/"><img src="/assets/media/sponsors/logo-u2u.png" class="sponsor-silver" vspace="20" /></a>
 
-<!--
+
 <a href="https://www.allphi.eu/"><img src="/assets/media/sponsors/logo-allphi.png" class="sponsor-silver" vspace="20"/></a>&nbsp;
 <a href="https://www.jetbrains.com/"><img src="/assets/media/sponsors/logo-jetbrains.jpg" class="sponsor-silver" vspace="20" /></a>&nbsp;
 


### PR DESCRIPTION
This pull request updates the partners listing in the `_includes/partners.html` file, primarily restructuring the Platinum and Silver partners sections. The main changes involve adjusting which sponsors are displayed, updating the HTML structure, and commenting or uncommenting certain partner entries.

Key changes include:

**Platinum partners section:**
- Updated the Platinum partners table
- Modified the list of Platinum partners shown in the image-only section, now displaying only Codit and Zure, and removing several others.

**Silver partners section:**
- Commented out the sponsors from the Silver partners image row, so it is no longer displayed.